### PR TITLE
[minio]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# Minio
+
+Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
+
+## Usage
+
+`hab svc start core/minio`
+
+Access the web browser on `http://fqdn:9000`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.minio?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # Minio
 
 Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,2 @@
+command_relative_path: '/bin/minio'
+listening_port: '9000'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,2 +1,2 @@
-command_relative_path: '/bin/minio'
+command_relative_path: 'bin/minio'
 listening_port: '9000'

--- a/controls/minio_exists.rb
+++ b/controls/minio_exists.rb
@@ -2,6 +2,7 @@ title 'Tests to confirm minio exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'minio')
+command_relative_path = input('command_relative_path', value: 'bin/minio')
 
 control 'core-plans-minio-exists' do
   impact 1.0
@@ -15,8 +16,7 @@ control 'core-plans-minio-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/minio')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/minio_exists.rb
+++ b/controls/minio_exists.rb
@@ -1,0 +1,23 @@
+title 'Tests to confirm minio exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'minio')
+
+control 'core-plans-minio-exists' do
+  impact 1.0
+  title 'Ensure minio exists'
+  desc '
+  Verify minio by ensuring /bin/minio exists'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/minio')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/minio_habservice_works.rb
+++ b/controls/minio_habservice_works.rb
@@ -1,0 +1,39 @@
+title 'Tests to confirm minio habitat service works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'minio')
+
+control 'core-plans-minio-habservice-works' do
+  impact 1.0
+  title 'Ensure minio habitat service works as expected'
+  desc '
+  Verify minio habitat service by ensuring that 
+  (1) the default.minio habitat service is "up"; 
+  (2) the minio process is LISTENing on the expected port.  Note the regex that 
+  detects the LISTENing <program> works in both a habitat studio environment
+  and a docker one.  In studio the program is displayed like "1234/minio";
+  whereas in docker as "-".
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  describe command("hab svc status") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /(?<package>#{plan_pkg_ident})\s+(?<type>standalone)\s+(?<desired>up)\s+(?<state>up)/ }
+    its('stderr') { should be_empty }
+  end
+
+  listening_port=input('listening_port', value: '9000')
+  describe command("hab pkg exec core/busybox-static netstat -peanut") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /:(?<port>#{listening_port}).*LISTEN\s+(?<program>-|\d+\/#{plan_name})/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/minio_works.rb
+++ b/controls/minio_works.rb
@@ -2,6 +2,7 @@ title 'Tests to confirm minio works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'minio')
+command_relative_path = input('command_relative_path', value: 'bin/minio')
 
 control 'core-plans-minio-works' do
   impact 1.0
@@ -9,10 +10,10 @@ control 'core-plans-minio-works' do
   desc '
   Verify minio by ensuring 
   (1) its installation directory exists and 
-  (2) that it returns the expected version.  Since minio --help returns a version
-  like "2019-07-31T18:57:56Z" with colons but the plan_pkg_version (derived from the plan_pkg_ident)
-  only contains hyphens "-", then logical equivalence is achieved by transforming 
-  plan_pkg_version ==> minio_version_with_colons below
+  (2) that it returns the expected version.  Since some platforms return slightly
+  different formats of minio version, some with colons like "2019-07-31T18:57:56Z" 
+  others without like "2019-07-31T18:57:56Z", then only the date portion is being 
+  used for a successful match.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -21,14 +22,12 @@ control 'core-plans-minio-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  version_element = plan_pkg_version.split("-")
-  minio_version_with_colons = "#{version_element[0]}-#{version_element[1]}-#{version_element[2]}:#{version_element[3]}:#{version_element[4]}"
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} minio --help") do
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  describe command("#{command_full_path} --help") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /#{minio_version_with_colons}/ }
+    its('stdout') { should match /#{plan_pkg_version.split("T")[0]}/ }
     its('stderr') { should be_empty }
   end
 end

--- a/controls/minio_works.rb
+++ b/controls/minio_works.rb
@@ -1,0 +1,34 @@
+title 'Tests to confirm minio works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'minio')
+
+control 'core-plans-minio-works' do
+  impact 1.0
+  title 'Ensure minio works as expected'
+  desc '
+  Verify minio by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.  Since minio --help returns a version
+  like "2019-07-31T18:57:56Z" with colons but the plan_pkg_version (derived from the plan_pkg_ident)
+  only contains hyphens "-", then logical equivalence is achieved by transforming 
+  plan_pkg_version ==> minio_version_with_colons below
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  version_element = plan_pkg_version.split("-")
+  minio_version_with_colons = "#{version_element[0]}-#{version_element[1]}-#{version_element[2]}:#{version_element[3]}:#{version_element[4]}"
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} minio --help") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{minio_version_with_colons}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 exec 2>&1
 
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done
+exec minio server \
+--config-dir {{pkg.svc_config_path}} \
+{{pkg.svc_data_path}}

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: minio
+title: Habitat Core Plan minio
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan minio
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,28 @@
+pkg_name=minio
+pkg_origin=core
+pkg_version="2019-07-31T18-57-56Z"
+pkg_description="Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure."
+pkg_upstream_url="https://minio.io"
+pkg_source="https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.${pkg_version}"
+pkg_shasum=78fc08a095bd1985a96ebc727fd3855840dd2c79d6f3bd2b542a940d7b183a42
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_bin_dirs=(bin)
+
+do_unpack() {
+  return 0
+}
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  mkdir -p "${pkg_prefix}/bin"
+  cp "../minio.RELEASE.${pkg_version}" "${pkg_prefix}/bin/minio"
+  chmod +x "${pkg_prefix}/bin/minio"
+}
+
+do_strip() {
+  return 0
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,20 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches, via help output" {
+  result=$(hab pkg exec ${TEST_PKG_IDENT} minio --help | tail -1 | tr -d ' ' | sed 's/:/-/g')
+  [ "$?" -eq 0 ]
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Service is running" {
+  [ "$(hab svc status | grep "minio\.default" | awk '{print $4}' | grep up)" ]
+}
+
+@test "A single process" {
+  result="$(ps aux | grep -v grep | grep "minio server" | wc -l)"
+  [ "${result}" -eq 1 ]
+}
+
+@test "Listening on port 9000" {
+  [ "$(netstat -peanut | grep minio | awk '{print $4}' | awk -F':' '{print $NF}' | grep 9000)" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+source "$(dirname "${0}")/../../bin/ci/test_helpers.sh"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install core/busybox-static
+hab pkg binlink core/busybox-static netstat
+hab pkg binlink core/busybox-static ps
+hab pkg binlink core/busybox-static wc
+hab pkg install "${TEST_PKG_IDENT}"
+
+ci_ensure_supervisor_running
+ci_load_service "${TEST_PKG_IDENT}"
+
+# Allow service start
+WAIT_SECONDS=5
+echo "Waiting ${WAIT_SECONDS} seconds for service to start..."
+sleep "${WAIT_SECONDS}"
+
+bats "$(dirname "${0}")/test.bats"
+
+hab svc unload "${TEST_PKG_IDENT}" || true


### PR DESCRIPTION
Note:
* Minio is a habitat service so is not using the default chef-base-plans run hook